### PR TITLE
feat: make core IO agnostic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,6 +130,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
 name = "async-compression"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,12 +398,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
-name = "datafrog"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0afaad2b26fa326569eb264b1363e8ae3357618c43982b3f285f0774ce76b69"
-
-[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -453,6 +453,16 @@ name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
+name = "env_logger"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
+dependencies = [
+ "log",
+ "regex",
+]
 
 [[package]]
 name = "env_logger"
@@ -999,6 +1009,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9376a4f0340565ad675d11fc1419227faf5f60cd7ac9cb2e7185a471f30af833"
 
 [[package]]
+name = "maud"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0bab19cef8a7fe1c18a43e881793bfc9d4ea984befec3ae5bd0415abf3ecf00"
+dependencies = [
+ "itoa",
+ "maud_macros",
+]
+
+[[package]]
+name = "maud_macros"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be95d66c3024ffce639216058e5bae17a83ecaf266ffc6e4d060ad447c9eed2"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1165,12 +1197,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "pachadb-backend-cloudflare"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "pachadb-core",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "worker",
+]
+
+[[package]]
 name = "pachadb-cli"
 version = "0.0.0"
 dependencies = [
  "anyhow",
  "chrono",
- "env_logger",
+ "env_logger 0.10.0",
  "human-panic",
  "pachadb-core",
  "pachadb-nanolog",
@@ -1190,16 +1234,39 @@ name = "pachadb-core"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "assert_matches",
  "async-recursion",
  "async-trait",
  "chrono",
  "futures",
  "pachadb-nanolog",
+ "quickcheck",
+ "quickcheck_async",
  "serde",
  "serde_derive",
  "serde_json",
  "thiserror",
+ "tokio",
  "uuid",
+]
+
+[[package]]
+name = "pachadb-examples-cloudflare-simple"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "console_error_panic_hook",
+ "futures",
+ "log",
+ "maud",
+ "pachadb-backend-cloudflare",
+ "pachadb-core",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "uuid",
+ "wasm-logger",
+ "worker",
 ]
 
 [[package]]
@@ -1208,6 +1275,7 @@ version = "0.1.0"
 dependencies = [
  "lalrpop",
  "lalrpop-util",
+ "quickcheck",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1220,76 +1288,6 @@ version = "0.1.0"
 dependencies = [
  "pachadb-nanolog",
  "rustyline",
-]
-
-[[package]]
-name = "pachadb-worker-consolidation"
-version = "0.1.0"
-dependencies = [
- "chrono",
- "console_error_panic_hook",
- "futures",
- "log",
- "pachadb-core",
- "reqwest",
- "serde",
- "serde_json",
- "uuid",
- "wasm-logger",
- "worker",
-]
-
-[[package]]
-name = "pachadb-worker-indexing"
-version = "0.1.0"
-dependencies = [
- "chrono",
- "console_error_panic_hook",
- "futures",
- "log",
- "pachadb-core",
- "reqwest",
- "serde",
- "serde_json",
- "uuid",
- "wasm-logger",
- "worker",
-]
-
-[[package]]
-name = "pachadb-worker-intake"
-version = "0.1.0"
-dependencies = [
- "chrono",
- "console_error_panic_hook",
- "futures",
- "log",
- "pachadb-core",
- "reqwest",
- "serde",
- "serde_json",
- "uuid",
- "wasm-logger",
- "worker",
-]
-
-[[package]]
-name = "pachadb-worker-query"
-version = "0.1.0"
-dependencies = [
- "chrono",
- "console_error_panic_hook",
- "datafrog",
- "futures",
- "log",
- "pachadb-core",
- "pachadb-nanolog",
- "reqwest",
- "serde",
- "serde_json",
- "uuid",
- "wasm-logger",
- "worker",
 ]
 
 [[package]]
@@ -1396,18 +1394,18 @@ checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030ad2bc4db10a8944cb0d837f158bdfec4d4a4873ab701a95046770d11f8842"
+checksum = "fda4ed1c6c173e3fc7a83629421152e01d7b1f9b7f65fb301e490e8cfc656422"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
+checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1475,6 +1473,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quickcheck"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
+dependencies = [
+ "env_logger 0.8.4",
+ "log",
+ "rand",
+]
+
+[[package]]
+name = "quickcheck_async"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "247df671941313a4e255a5015772917368f1b21bfedfbd89d68fbb27e802b2fa"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,10 +144,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-trait"
-version = "0.1.72"
+name = "async-recursion"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6dde6e4ed435a4c1ee4e73592f5ba9da2151af10076cc04858746af9352d09"
+checksum = "0e97ce7de6cf12de5d7226c73f5ba9811622f4db3a5b91b55c53e987e5f91cba"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.28",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1178,11 +1189,17 @@ dependencies = [
 name = "pachadb-core"
 version = "0.0.0"
 dependencies = [
+ "anyhow",
+ "async-recursion",
+ "async-trait",
  "chrono",
+ "futures",
+ "pachadb-nanolog",
  "serde",
  "serde_derive",
  "serde_json",
  "thiserror",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,10 +4,12 @@ members = [
   "core",
   "nanolog",
   "nanolog-repl",
-  "worker-consolidation",
-  "worker-indexing",
-  "worker-intake",
-  "worker-query",
+  "backend-cloudflare",
+  "examples/cloudflare-simple",
+  # "worker-intake",
+  # "worker-query",
+  # "worker-indexing",
+  # "worker-consolidation",
 ]
 resolver = "2"
 
@@ -17,14 +19,21 @@ lto = true
 
 [workspace.dependencies]
 anyhow = "1"
+assert_matches = "1.5.0"
+async-recursion = "1.0.4"
 async-trait = "0.1.73"
 chrono = "0.4"
 datafrog = "2.0.1"
 env_logger = "0.10.0"
 futures = "0.3.28"
 human-panic = "1.1.5"
+lalrpop = "0.20"
+lalrpop-util = { version = "0.20", features = ["lexer", "unicode"] }
 log = "0.4.19"
+quickcheck = "1.0.3"
+quickcheck_async = "0.1.1"
 reqwest = { version = "0.11", features = ["json", "gzip", "brotli"] }
+rustyline = "12.0.0"
 serde = { version = "1.0", features = ["rc"] }
 serde_derive = "1.0"
 serde_json = { version = "1.0", features = ["preserve_order"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ lto = true
 
 [workspace.dependencies]
 anyhow = "1"
+async-trait = "0.1.73"
 chrono = "0.4"
 datafrog = "2.0.1"
 env_logger = "0.10.0"

--- a/backend-cloudflare/Cargo.toml
+++ b/backend-cloudflare/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "pachadb-backend-cloudflare"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+pachadb-core = { path = "../core", version = "*" }
+
+worker.workspace = true
+async-trait.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+serde_derive.workspace = true

--- a/backend-cloudflare/src/lib.rs
+++ b/backend-cloudflare/src/lib.rs
@@ -1,0 +1,157 @@
+use async_trait::async_trait;
+use pachadb_core::*;
+use std::sync::Arc;
+use worker::*;
+
+#[derive(Clone)]
+pub struct CloudflareStore {
+    indexing_queue: Arc<Queue>,
+    consolidation_queue: Arc<Queue>,
+    tx_manager_do: Arc<ObjectNamespace>,
+    fact_bucket: Arc<kv::KvStore>,
+    tx_bucket: Arc<kv::KvStore>,
+    index_by_entity: Arc<kv::KvStore>,
+    index_by_entity_field: Arc<kv::KvStore>,
+    index_by_field: Arc<kv::KvStore>,
+    index_by_field_value: Arc<kv::KvStore>,
+    index_by_value: Arc<kv::KvStore>,
+}
+
+impl CloudflareStore {
+    pub async fn dangerous_reset_transaction_id_to_zero(&self) -> Result<()> {
+        let obj_id = self.tx_manager_do.id_from_name("main")?;
+        let stub = obj_id.get_stub()?;
+
+        stub.fetch_with_str(
+            "https://tx-manager.pachadb.com/dangeours-reset-transaction-id-to-zero",
+        )
+        .await?
+        .text()
+        .await?;
+
+        Ok(())
+    }
+
+    pub fn new(env: &Env) -> Result<Self> {
+        Ok(Self {
+            tx_manager_do: Arc::new(env.durable_object("PACHADB_TX_MANAGER")?),
+            indexing_queue: Arc::new(env.queue("pachadb-facts-indexing-queue")?),
+            consolidation_queue: Arc::new(env.queue("pachadb-facts-consolidation-queue")?),
+            fact_bucket: Arc::new(env.kv("pachadb-facts-store")?),
+            tx_bucket: Arc::new(env.kv("pachadb-tx-store")?),
+            index_by_entity: Arc::new(env.kv("pachadb-facts-index-by-entity")?),
+            index_by_entity_field: Arc::new(env.kv("pachadb-facts-index-by-entity-field")?),
+            index_by_field: Arc::new(env.kv("pachadb-facts-index-by-field")?),
+            index_by_field_value: Arc::new(env.kv("pachadb-facts-index-by-field-value")?),
+            index_by_value: Arc::new(env.kv("pachadb-facts-index-by-value")?),
+        })
+    }
+
+    async fn _get_next_tx_id(&self) -> Result<TxId> {
+        let obj_id = self.tx_manager_do.id_from_name("main")?;
+
+        let stub = obj_id.get_stub()?;
+
+        stub.fetch_with_str("https://tx-manager.pachadb.com/new")
+            .await?
+            .json()
+            .await
+    }
+
+    async fn _store_facts(&self, facts: impl Iterator<Item = &Fact>) -> Result<()> {
+        for fact in facts {
+            let json = serde_json::to_string(fact)?;
+            self.fact_bucket.put(&fact.id.0, json)?.execute().await?;
+        }
+        Ok(())
+    }
+
+    async fn _store_transaction(&self, tx: &Transaction) -> Result<()> {
+        self.tx_bucket
+            .put(&tx.id.to_string(), tx.clone())?
+            .execute()
+            .await?;
+        Ok(())
+    }
+}
+
+#[async_trait(?Send)]
+impl pachadb_core::Store for CloudflareStore {
+    async fn get_tx_id(&self) -> PachaResult<TxId> {
+        todo!()
+    }
+
+    async fn get_next_tx_id(&self) -> PachaResult<TxId> {
+        self._get_next_tx_id()
+            .await
+            .map_err(|err| PachaError::UnrecoverableStorageError(err.to_string()))
+    }
+
+    async fn put_facts(&self, facts: impl Iterator<Item = &Fact>) -> PachaResult<()> {
+        self._store_facts(facts)
+            .await
+            .map_err(|err| PachaError::UnrecoverableStorageError(err.to_string()))?;
+        Ok(())
+    }
+
+    async fn put_transaction(&self, tx: &Transaction) -> PachaResult<()> {
+        self._store_transaction(tx)
+            .await
+            .map_err(|err| PachaError::UnrecoverableStorageError(err.to_string()))?;
+        Ok(())
+    }
+
+    async fn get_fact(&self, _uri: Uri) -> PachaResult<Option<Fact>> {
+        todo!()
+    }
+}
+
+#[async_trait(?Send)]
+impl pachadb_core::Index for CloudflareStore {
+    async fn put(&self, facts: impl Iterator<Item = &Fact>) -> PachaResult<()> {
+        for fact in facts {
+            self.indexing_queue
+                .send(&fact.id)
+                .await
+                .map_err(|err| PachaError::UnrecoverableStorageError(err.to_string()))?;
+        }
+        Ok(())
+    }
+
+    async fn scan(&self, scan: Scan) -> PachaResult<Box<dyn Iterator<Item = IndexKey>>> {
+        let prefix = scan.to_prefix();
+
+        let list = self
+            .index_by_field_value
+            .list()
+            .prefix(prefix)
+            .execute()
+            .await
+            .map_err(|err| PachaError::UnrecoverableStorageError(err.to_string()))?;
+
+        Ok(Box::new(
+            list.keys.into_iter().map(|key| key.name.parse().unwrap()),
+        ))
+    }
+
+    async fn get(&self, key: IndexKey) -> PachaResult<Option<Uri>> {
+        self.index_by_field_value
+            .get(&key.to_string())
+            .json::<Uri>()
+            .await
+            .map_err(|err| PachaError::UnrecoverableStorageError(err.to_string()))
+    }
+}
+
+#[async_trait(?Send)]
+impl pachadb_core::Consolidator for CloudflareStore {
+    async fn consolidate(&self, facts: impl Iterator<Item = &Fact>) -> PachaResult<()> {
+        for fact in facts {
+            self.consolidation_queue
+                .send(&fact.id)
+                .await
+                .map_err(|err| PachaError::UnrecoverableStorageError(err.to_string()))?;
+        }
+        Ok(())
+    }
+}

--- a/cli/commands/state.rs
+++ b/cli/commands/state.rs
@@ -1,6 +1,6 @@
 use crate::flags::Flags;
 use anyhow::*;
-use pachadb_core::Uri;
+use pachadb_core::{Uri, Value};
 use reqwest::Method;
 use structopt::StructOpt;
 
@@ -33,7 +33,7 @@ impl StateCommand {
                 entity: Uri(self.entity.clone()),
                 field: Uri(self.field.clone()),
                 source: Uri(format!("system:{}", whoami::username())),
-                value: self.value.clone(),
+                value: Value::String(self.value.clone()),
                 stated_at: chrono::Utc::now(),
             }],
         };

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -7,12 +7,18 @@ edition = "2021"
 pachadb-nanolog = { path = "../nanolog", version = "*" }
 
 anyhow.workspace = true
+assert_matches.workspace = true
+async-recursion.workspace = true
 async-trait.workspace = true
 chrono.workspace = true
+futures.workspace = true
+quickcheck_async.workspace = true
 serde.workspace = true
 serde_derive.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 uuid.workspace = true
-futures.workspace = true
-async-recursion = "1.0.4"
+
+[dev-dependencies]
+quickcheck.workspace = true
+tokio.workspace = true

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -3,11 +3,16 @@ name = "pachadb-core"
 version = "0.0.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
+pachadb-nanolog = { path = "../nanolog", version = "*" }
+
+anyhow.workspace = true
+async-trait.workspace = true
 chrono.workspace = true
 serde.workspace = true
 serde_derive.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
+uuid.workspace = true
+futures.workspace = true
+async-recursion = "1.0.4"

--- a/core/src/backend/memory.rs
+++ b/core/src/backend/memory.rs
@@ -1,0 +1,86 @@
+use crate::*;
+use async_trait::async_trait;
+use std::collections::HashMap;
+use std::sync::RwLock;
+
+#[derive(Default, Clone, Debug)]
+pub struct InMemoryStore {
+    tx_id: Arc<RwLock<TxId>>,
+    facts: Arc<RwLock<HashMap<Uri, Fact>>>,
+    txs: Arc<RwLock<Vec<Transaction>>>,
+}
+
+#[async_trait(?Send)]
+impl Store for InMemoryStore {
+    async fn get_tx_id(&self) -> PachaResult<TxId> {
+        let tx_id = self.tx_id.read().unwrap();
+        Ok(*tx_id)
+    }
+
+    async fn get_next_tx_id(&self) -> PachaResult<TxId> {
+        let tx_id = self.get_tx_id().await?;
+        let next_tx_id = tx_id.next();
+        (*self.tx_id.write().unwrap()) = next_tx_id;
+        Ok(tx_id)
+    }
+
+    async fn put_facts(&self, facts: impl Iterator<Item = &Fact>) -> PachaResult<()> {
+        let mut fact_map = self.facts.write().unwrap();
+        for fact in facts {
+            fact_map.insert(fact.id.clone(), fact.clone());
+        }
+        Ok(())
+    }
+
+    async fn put_transaction(&self, tx: &Transaction) -> PachaResult<()> {
+        self.txs.write().unwrap().push(tx.clone());
+        Ok(())
+    }
+
+    async fn get_fact(&self, uri: Uri) -> PachaResult<Option<Fact>> {
+        Ok(self.facts.read().unwrap().get(&uri).cloned())
+    }
+}
+
+#[derive(Default, Clone, Debug)]
+pub struct InMemoryIndex {
+    // NOTE(@ostera): very naive in-memory index. Would be best to use a prefix trie for scans.
+    idx: Arc<RwLock<HashMap<IndexKey, Uri>>>,
+}
+
+#[async_trait(?Send)]
+impl Index for InMemoryIndex {
+    async fn put(&self, facts: impl Iterator<Item = &Fact>) -> PachaResult<()> {
+        let mut idx = self.idx.write().unwrap();
+        for fact in facts {
+            for key in IndexKeySet::from_fact(fact).keys() {
+                idx.insert(key, fact.id.clone());
+            }
+        }
+        Ok(())
+    }
+
+    async fn scan(&self, scan: Scan) -> PachaResult<Box<dyn Iterator<Item = IndexKey>>> {
+        let prefix = scan.to_prefix();
+        let mut keys = vec![];
+        for key in self.idx.read().unwrap().keys() {
+            if key.starts_with(&prefix) {
+                keys.push(key.clone());
+            }
+        }
+        Ok(Box::new(keys.into_iter()))
+    }
+
+    async fn get(&self, key: IndexKey) -> PachaResult<Option<Uri>> {
+        Ok(self.idx.read().unwrap().get(&key).cloned())
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct InMemoryConsolidator;
+#[async_trait(?Send)]
+impl Consolidator for InMemoryConsolidator {
+    async fn consolidate(&self, _facts: impl Iterator<Item = &Fact>) -> PachaResult<()> {
+        Ok(())
+    }
+}

--- a/core/src/backend/mod.rs
+++ b/core/src/backend/mod.rs
@@ -1,0 +1,1 @@
+pub mod memory;

--- a/core/src/consolidation.rs
+++ b/core/src/consolidation.rs
@@ -1,0 +1,7 @@
+use crate::*;
+use async_trait::async_trait;
+
+#[async_trait(?Send)]
+pub trait Consolidator {
+    async fn consolidate(&self, _facts: impl Iterator<Item = &Fact>) -> PachaResult<()>;
+}

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -1,0 +1,22 @@
+use pachadb_nanolog::parser::ParseError;
+use thiserror::*;
+
+#[derive(Error, Debug)]
+pub enum PachaError {
+    #[error("Unrecoverable storage errror. Reason: {0}")]
+    UnrecoverableStorageError(String),
+
+    #[error(transparent)]
+    QueryParsingError(ParseError),
+
+    #[error(transparent)]
+    Unknown(anyhow::Error),
+}
+
+impl From<ParseError> for PachaError {
+    fn from(value: ParseError) -> Self {
+        Self::QueryParsingError(value)
+    }
+}
+
+pub type PachaResult<V> = std::result::Result<V, PachaError>;

--- a/core/src/index.rs
+++ b/core/src/index.rs
@@ -1,0 +1,101 @@
+use crate::*;
+use async_trait::async_trait;
+use serde_derive::{Deserialize, Serialize};
+use std::str::FromStr;
+
+#[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq, Serialize, Deserialize)]
+pub struct IndexKeySet {
+    index_by_entity: IndexKey,
+    index_by_entity_field: IndexKey,
+    index_by_field: IndexKey,
+    index_by_field_value: IndexKey,
+    index_by_value: IndexKey,
+}
+
+impl IndexKeySet {
+    pub fn from_fact(fact: &Fact) -> Self {
+        IndexKeySet {
+            index_by_entity: IndexKey::new(
+                fact.tx_id,
+                fact.id.clone(),
+                vec![fact.entity.clone().into()],
+            ),
+            index_by_entity_field: IndexKey::new(
+                fact.tx_id,
+                fact.id.clone(),
+                vec![fact.entity.clone().into(), fact.field.clone().into()],
+            ),
+            index_by_field: IndexKey::new(
+                fact.tx_id,
+                fact.id.clone(),
+                vec![fact.field.clone().into()],
+            ),
+            index_by_field_value: IndexKey::new(
+                fact.tx_id,
+                fact.id.clone(),
+                vec![fact.field.clone().into(), fact.value.clone()],
+            ),
+            index_by_value: IndexKey::new(fact.tx_id, fact.id.clone(), vec![fact.value.clone()]),
+        }
+    }
+
+    pub fn keys(self) -> Vec<IndexKey> {
+        vec![
+            self.index_by_entity,
+            self.index_by_entity_field,
+            self.index_by_field,
+            self.index_by_field_value,
+            self.index_by_value,
+        ]
+    }
+}
+
+#[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize)]
+pub struct IndexKey {
+    pub tx_id: TxId,
+    pub fact_uri: Uri,
+    pub prefix: Vec<Value>,
+}
+
+impl IndexKey {
+    pub fn new(tx_id: TxId, fact_uri: Uri, prefix: Vec<Value>) -> Self {
+        Self {
+            tx_id,
+            fact_uri,
+            prefix,
+        }
+    }
+
+    pub fn starts_with(&self, prefix: impl AsRef<str>) -> bool {
+        self.to_string().starts_with(prefix.as_ref())
+    }
+}
+
+impl ToString for IndexKey {
+    fn to_string(&self) -> String {
+        let prefix = self
+            .prefix
+            .iter()
+            .map(|v| v.to_string())
+            .collect::<Vec<String>>()
+            .join("/");
+        format!("{}/{}", prefix, self.tx_id.0)
+    }
+}
+
+impl FromStr for IndexKey {
+    type Err = PachaError;
+
+    fn from_str(_key: &str) -> Result<Self, Self::Err> {
+        todo!()
+    }
+}
+
+#[async_trait(?Send)]
+pub trait Index: Clone {
+    async fn put(&self, facts: impl Iterator<Item = &Fact>) -> PachaResult<()>;
+
+    async fn scan(&self, prefix: Scan) -> PachaResult<Box<dyn Iterator<Item = IndexKey>>>;
+
+    async fn get(&self, key: IndexKey) -> PachaResult<Option<Uri>>;
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,412 +1,81 @@
+pub mod backend;
+mod consolidation;
+mod error;
+mod index;
+mod model;
+mod query_executor;
+mod query_planner;
+mod store;
+mod tx_manager;
 mod util;
 
-use async_recursion::async_recursion;
-use async_trait::async_trait;
-use chrono::{DateTime, Utc};
-use pachadb_nanolog::{
-    atom,
-    engine::{Atom, Rule, Solver, Term},
-    parser::{ParseError, Parser},
-    rule, sym,
-};
-use serde_derive::{Deserialize, Serialize};
-use std::{collections::HashMap, str::FromStr};
-use thiserror::*;
+pub use consolidation::*;
+pub use error::*;
+pub use index::*;
+pub use model::*;
+pub use query_executor::*;
+pub use query_planner::*;
+pub use store::*;
+pub use tx_manager::*;
 
-#[derive(Error, Debug)]
-pub enum PachaError {
-    #[error("Unrecoverable storage errror. Reason: {0}")]
-    UnrecoverableStorageError(String),
+use pachadb_nanolog::engine::Atom;
+use pachadb_nanolog::parser::Parser;
+use std::sync::Arc;
 
-    #[error(transparent)]
-    QueryParsingError(ParseError),
+#[cfg(test)]
+#[macro_use]
+extern crate assert_matches;
 
-    #[error(transparent)]
-    Unknown(anyhow::Error),
+#[cfg(test)]
+#[macro_use]
+extern crate quickcheck_async;
+
+pub struct PachaDb<S: Store, Idx: Index, C: Consolidator> {
+    tx_manager: DefaultTxManager<S, Idx, C>,
+    query_planner: DefaultQueryPlanner,
+    query_executor: DefaultQueryExecutor<S, Idx>,
 }
 
-impl From<ParseError> for PachaError {
-    fn from(value: ParseError) -> Self {
-        Self::QueryParsingError(value)
-    }
-}
-
-pub type PachaResult<V> = std::result::Result<V, PachaError>;
-
-#[derive(Debug, Clone, Hash, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
-#[serde(transparent)]
-pub struct Uri(pub String);
-
-#[derive(Default, Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
-#[serde(transparent)]
-pub struct TxId(pub u64);
-
-impl TxId {
-    pub fn next(&self) -> Self {
-        Self(self.0 + 1)
-    }
-}
-
-impl ToString for TxId {
-    fn to_string(&self) -> String {
-        self.0.to_string()
-    }
-}
-
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
-pub struct Transaction {
-    pub id: TxId,
-    pub fact_ids: Vec<Uri>,
-    pub facts: Vec<Fact>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Fact {
-    pub tx_id: TxId,
-    pub id: Uri,
-    pub entity: Uri,
-    pub field: Uri,
-    pub source: Uri,
-    pub value: String,
-    #[serde(with = "util::serde::iso8601")]
-    pub stated_at: DateTime<Utc>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct UserFact {
-    pub entity: Uri,
-    pub field: Uri,
-    pub source: Uri,
-    pub value: String,
-    #[serde(with = "util::serde::iso8601")]
-    pub stated_at: DateTime<Utc>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct QueryReq {
-    pub query: String,
-    pub tx_id: TxId,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct StateFactsReq {
-    pub facts: Vec<UserFact>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct StateFactsRes {
-    pub tx_id: TxId,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Entity {
-    pub uri: Uri,
-    pub fields: HashMap<Uri, String>,
-    pub prior_facts: HashMap<Uri, Fact>,
-    #[serde(with = "util::serde::iso8601")]
-    pub created_at: DateTime<Utc>,
-    #[serde(with = "util::serde::iso8601")]
-    pub last_updated_at: DateTime<Utc>,
-}
-
-impl Entity {
-    pub fn new(uri: Uri) -> Self {
-        Self {
-            uri,
-            created_at: chrono::Utc::now(),
-            last_updated_at: chrono::Utc::now(),
-            fields: Default::default(),
-            prior_facts: Default::default(),
-        }
-    }
-
-    pub fn consolidate(&mut self, fact: Fact) {
-        if let Some(prior_fact) = self.prior_facts.get(&fact.field) {
-            if fact.stated_at >= prior_fact.stated_at {
-                self.insert_fact(fact);
-            }
-        } else {
-            self.insert_fact(fact);
-        }
-    }
-
-    pub fn insert_fact(&mut self, fact: Fact) {
-        self.fields.insert(fact.field.clone(), fact.value.clone());
-        self.prior_facts.insert(fact.field.clone(), fact);
-        self.last_updated_at = chrono::Utc::now();
-    }
-}
-
-#[async_trait(?Send)]
-pub trait TxStorage {
-    async fn get_next_tx_id(&self) -> PachaResult<TxId>;
-
-    async fn store_facts(&self, facts: &[Fact]) -> PachaResult<()>;
-
-    async fn store_transaction(&self, tx: &Transaction) -> PachaResult<()>;
-}
-
-#[async_trait(?Send)]
-pub trait TxManager {
-    async fn transaction(&self, facts: Vec<UserFact>) -> PachaResult<Transaction>;
-
-    async fn commit(&self, tx: Transaction) -> PachaResult<TxId>;
-}
-
-#[async_trait(?Send)]
-pub trait Indexer {
-    async fn index(&self, facts: &[Fact]) -> PachaResult<()>;
-}
-
-#[async_trait(?Send)]
-pub trait Consolidator {
-    async fn consolidate(&self, consolidate: &[Fact]) -> PachaResult<()>;
-}
-
-pub struct DefaultTxManager<S: TxStorage, I: Indexer, C: Consolidator> {
-    storage: S,
-    indexer: I,
-    consolidator: C,
-}
-
-impl<S: TxStorage, I: Indexer, C: Consolidator> DefaultTxManager<S, I, C> {
-    pub fn new(storage: S, indexer: I, consolidator: C) -> Self {
-        Self {
-            storage,
-            indexer,
-            consolidator,
-        }
-    }
-}
-
-#[async_trait(?Send)]
-impl<S, I, C> TxManager for DefaultTxManager<S, I, C>
+impl<S, Idx, C> PachaDb<S, Idx, C>
 where
-    S: TxStorage,
-    I: Indexer,
+    S: Store,
+    Idx: Index,
     C: Consolidator,
 {
-    async fn transaction(&self, facts: Vec<UserFact>) -> PachaResult<Transaction> {
-        let tx_id: TxId = self.storage.get_next_tx_id().await?;
-
-        let facts = facts
-            .into_iter()
-            .map(|fact| Fact {
-                tx_id,
-                id: Uri(format!("pachadb:fact:{}", uuid::Uuid::new_v4())),
-                entity: fact.entity,
-                field: fact.field,
-                source: fact.source,
-                value: fact.value,
-                stated_at: fact.stated_at,
-            })
-            .collect();
-
-        Ok(Transaction {
-            id: tx_id,
-            fact_ids: vec![],
-            facts,
-        })
-    }
-
-    async fn commit(&self, tx: Transaction) -> PachaResult<TxId> {
-        self.storage.store_facts(&tx.facts).await?;
-        self.storage.store_transaction(&tx).await?;
-        self.indexer.index(&tx.facts).await?;
-        self.consolidator.consolidate(&tx.facts).await?;
-        Ok(tx.id)
-    }
-}
-
-pub enum Scan {
-    Entity(String),
-    EntityField(String, String),
-    Field(String),
-    FieldValue(String, String),
-    EntityValue(String, String),
-    Value(String),
-}
-
-pub enum QueryPlan {
-    RunScan(TxId, Vec<Scan>, Box<QueryPlan>),
-    Solve,
-}
-
-#[async_trait(?Send)]
-pub trait QueryPlanner {
-    async fn plan_query(&self, query: String, tx_id: TxId) -> PachaResult<QueryPlan>;
-}
-
-#[derive(Default)]
-pub struct DefaultQueryPlanner {}
-
-#[async_trait(?Send)]
-impl QueryPlanner for DefaultQueryPlanner {
-    async fn plan_query(&self, query: String, tx_id: TxId) -> PachaResult<QueryPlan> {
-        let query = Parser.parse(&query)?;
-
-        let scans: Vec<Scan> = query
-            .body
-            .iter()
-            .flat_map(|atom| match &atom.relation {
-                Term::Var(_) => {
-                    let entity = atom.args.get(0).unwrap();
-                    let value = atom.args.get(1).unwrap();
-                    match (entity, value) {
-                        (Term::Var(_), Term::Sym(v)) => vec![Scan::Value(v.clone())],
-                        (Term::Sym(e), Term::Var(_)) => vec![Scan::Entity(e.clone())],
-                        (Term::Sym(e), Term::Sym(v)) => {
-                            vec![Scan::EntityValue(e.clone(), v.clone())]
-                        }
-                        (Term::Var(_), Term::Var(_)) => vec![],
-                    }
-                }
-                Term::Sym(f) => {
-                    let entity = atom.args.get(0).unwrap();
-                    let value = atom.args.get(1).unwrap();
-                    match (entity, value) {
-                        (Term::Var(_), Term::Sym(v)) => {
-                            vec![Scan::FieldValue(f.clone(), v.clone())]
-                        }
-                        (Term::Sym(e), Term::Var(_)) => {
-                            vec![Scan::EntityField(e.clone(), f.clone())]
-                        }
-                        (Term::Sym(_), Term::Sym(_)) => vec![],
-                        (Term::Var(_), Term::Var(_)) => vec![Scan::Field(f.clone())],
-                    }
-                }
-            })
-            .collect();
-
-        Ok(QueryPlan::RunScan(tx_id, scans, QueryPlan::Solve.into()))
-    }
-}
-
-#[async_trait(?Send)]
-pub trait QueryExecutor {
-    async fn run_query_plan(&self, plan: QueryPlan) -> PachaResult<Vec<Atom>>;
-}
-
-pub struct IndexKey {
-    pub prefix: String,
-    pub tx_id: TxId,
-}
-
-impl ToString for IndexKey {
-    fn to_string(&self) -> String {
-        format!("{}/{}", self.prefix.clone(), self.tx_id.0)
-    }
-}
-
-impl FromStr for IndexKey {
-    type Err = PachaError;
-
-    fn from_str(key: &str) -> Result<Self, Self::Err> {
-        let fact_tx_id: u64 = key.split('/').last().unwrap().parse().unwrap();
-        Ok(Self {
-            prefix: key.to_string(),
-            tx_id: TxId(fact_tx_id),
-        })
-    }
-}
-
-#[async_trait(?Send)]
-pub trait IndexStore {
-    async fn scan(&self, prefix: &str) -> PachaResult<Box<dyn Iterator<Item = IndexKey>>>;
-    async fn get(&self, key: IndexKey) -> PachaResult<Option<Fact>>;
-}
-
-pub struct DefaultQueryExecutor<IS: IndexStore> {
-    scanner: IndexScanner<IS>,
-    solver: Solver,
-}
-
-#[async_trait(?Send)]
-impl<IS> QueryExecutor for DefaultQueryExecutor<IS>
-where
-    IS: IndexStore,
-{
-    async fn run_query_plan(&self, plan: QueryPlan) -> PachaResult<Vec<Atom>> {
-        self.do_run_query(plan, vec![]).await
-    }
-}
-
-impl<IS> DefaultQueryExecutor<IS>
-where
-    IS: IndexStore,
-{
-    pub fn new(scanner: IndexScanner<IS>) -> Self {
+    pub fn new(store: S, index: Idx, consolidator: C) -> Self {
+        let tx_manager = DefaultTxManager::new(store.clone(), index.clone(), consolidator);
+        let query_executor = DefaultQueryExecutor::new(store.clone(), index.clone());
         Self {
-            scanner,
-            solver: Solver,
+            tx_manager,
+            query_planner: DefaultQueryPlanner,
+            query_executor,
         }
     }
 
-    #[async_recursion(?Send)]
-    async fn do_run_query(&self, plan: QueryPlan, mut rules: Vec<Rule>) -> PachaResult<Vec<Atom>> {
-        match plan {
-            QueryPlan::RunScan(tx_id, scans, next) => {
-                for scan in scans {
-                    let new_rules = self.scanner.fetch(scan, tx_id).await?;
-                    rules.extend(new_rules);
-                }
-                self.do_run_query(*next, rules).await
-            }
-            QueryPlan::Solve => Ok(self.solver.solve(rules)),
-        }
+    pub async fn state(&mut self, facts: Vec<UserFact>) -> PachaResult<TxId> {
+        let tx = self.tx_manager.transaction(facts).await?;
+        self.tx_manager.commit(tx).await
+    }
+
+    pub async fn query(&mut self, query: impl AsRef<str>) -> PachaResult<Vec<Atom>> {
+        let query = Parser.parse(query.as_ref())?;
+        let tx_id = self.tx_manager.last_tx_id().await?;
+        let plan = self.query_planner.plan(query, tx_id)?;
+        self.query_executor.execute(plan).await
     }
 }
 
-pub struct IndexScanner<IS: IndexStore> {
-    index_by_entity: IS,
-    index_by_entity_field: IS,
-    index_by_entity_value: IS,
-    index_by_field: IS,
-    index_by_field_value: IS,
-    index_by_value: IS,
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::memory::*;
 
-impl<IS: IndexStore> IndexScanner<IS> {
-    pub fn new(
-        index_by_entity: IS,
-        index_by_entity_field: IS,
-        index_by_entity_value: IS,
-        index_by_field: IS,
-        index_by_field_value: IS,
-        index_by_value: IS,
-    ) -> Self {
-        Self {
-            index_by_entity,
-            index_by_entity_field,
-            index_by_entity_value,
-            index_by_field,
-            index_by_field_value,
-            index_by_value,
-        }
-    }
-
-    pub async fn fetch(&self, scan: Scan, max_tx: TxId) -> PachaResult<Vec<Rule>> {
-        let (kv, prefix) = match scan {
-            Scan::Entity(prefix) => (&self.index_by_entity, prefix),
-            Scan::EntityField(e, f) => (&self.index_by_entity_field, format!("{}/{}", e, f)),
-            Scan::Field(f) => (&self.index_by_field, f),
-            Scan::FieldValue(f, v) => (&self.index_by_field_value, format!("{}/{}", f, v)),
-            Scan::EntityValue(e, v) => (&self.index_by_entity_value, format!("{}/{}", e, v)),
-            Scan::Value(v) => (&self.index_by_value, v),
-        };
-
-        let mut rules = vec![];
-        for key in kv.scan(&prefix).await? {
-            if key.tx_id <= max_tx {
-                let fact = kv.get(key).await?.unwrap();
-                let rule = rule!(
-                    atom!(sym!(fact.entity.0), sym!(fact.field.0), sym!(fact.value)),
-                    vec![]
-                );
-                rules.push(rule);
-            }
-        }
-
-        Ok(rules)
+    #[tokio::test]
+    async fn simple_test() {
+        let _db = PachaDb::new(
+            InMemoryStore::default(),
+            InMemoryIndex::default(),
+            InMemoryConsolidator,
+        );
     }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,17 +1,37 @@
 mod util;
 
+use async_recursion::async_recursion;
+use async_trait::async_trait;
 use chrono::{DateTime, Utc};
+use pachadb_nanolog::{
+    atom,
+    engine::{Atom, Rule, Solver, Term},
+    parser::{ParseError, Parser},
+    rule, sym,
+};
 use serde_derive::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::{collections::HashMap, str::FromStr};
 use thiserror::*;
 
 #[derive(Error, Debug)]
-pub enum Error {
-    #[error("unknown error")]
-    Unknown,
+pub enum PachaError {
+    #[error("Unrecoverable storage errror. Reason: {0}")]
+    UnrecoverableStorageError(String),
+
+    #[error(transparent)]
+    QueryParsingError(ParseError),
+
+    #[error(transparent)]
+    Unknown(anyhow::Error),
 }
 
-pub type PachaResult<V> = std::result::Result<V, Error>;
+impl From<ParseError> for PachaError {
+    fn from(value: ParseError) -> Self {
+        Self::QueryParsingError(value)
+    }
+}
+
+pub type PachaResult<V> = std::result::Result<V, PachaError>;
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
 #[serde(transparent)]
@@ -27,10 +47,17 @@ impl TxId {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+impl ToString for TxId {
+    fn to_string(&self) -> String {
+        self.0.to_string()
+    }
+}
+
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct Transaction {
-    pub tx_id: TxId,
+    pub id: TxId,
     pub fact_ids: Vec<Uri>,
+    pub facts: Vec<Fact>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -68,7 +95,7 @@ pub struct StateFactsReq {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StateFactsRes {
-    pub facts: Vec<Fact>,
+    pub tx_id: TxId,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -110,24 +137,276 @@ impl Entity {
     }
 }
 
-pub trait EntityStore: Default {
-    fn put(&mut self, uri: Uri, val: Entity) -> PachaResult<()>;
-    fn get(&mut self, uri: Uri) -> PachaResult<Option<Entity>>;
+#[async_trait(?Send)]
+pub trait TxStorage {
+    async fn get_next_tx_id(&self) -> PachaResult<TxId>;
+
+    async fn store_facts(&self, facts: &[Fact]) -> PachaResult<()>;
+
+    async fn store_transaction(&self, tx: &Transaction) -> PachaResult<()>;
 }
 
-pub trait FactStore: Default {
-    fn put(&mut self, uri: Uri, val: Fact) -> PachaResult<()>;
-    fn get(&mut self, uri: Uri) -> PachaResult<Option<Fact>>;
+#[async_trait(?Send)]
+pub trait TxManager {
+    async fn transaction(&self, facts: Vec<UserFact>) -> PachaResult<Transaction>;
+
+    async fn commit(&self, tx: Transaction) -> PachaResult<TxId>;
 }
 
-#[derive(Debug, Default)]
-pub struct PachaDb<EntityStore, FactStore> {
-    entity_store: EntityStore,
-    fact_store: FactStore,
+#[async_trait(?Send)]
+pub trait Indexer {
+    async fn index(&self, facts: &[Fact]) -> PachaResult<()>;
 }
 
-impl<ES: EntityStore, FS: FactStore> PachaDb<ES, FS> {
-    pub fn new() -> Self {
-        Default::default()
+#[async_trait(?Send)]
+pub trait Consolidator {
+    async fn consolidate(&self, consolidate: &[Fact]) -> PachaResult<()>;
+}
+
+pub struct DefaultTxManager<S: TxStorage, I: Indexer, C: Consolidator> {
+    storage: S,
+    indexer: I,
+    consolidator: C,
+}
+
+impl<S: TxStorage, I: Indexer, C: Consolidator> DefaultTxManager<S, I, C> {
+    pub fn new(storage: S, indexer: I, consolidator: C) -> Self {
+        Self {
+            storage,
+            indexer,
+            consolidator,
+        }
+    }
+}
+
+#[async_trait(?Send)]
+impl<S, I, C> TxManager for DefaultTxManager<S, I, C>
+where
+    S: TxStorage,
+    I: Indexer,
+    C: Consolidator,
+{
+    async fn transaction(&self, facts: Vec<UserFact>) -> PachaResult<Transaction> {
+        let tx_id: TxId = self.storage.get_next_tx_id().await?;
+
+        let facts = facts
+            .into_iter()
+            .map(|fact| Fact {
+                tx_id,
+                id: Uri(format!("pachadb:fact:{}", uuid::Uuid::new_v4())),
+                entity: fact.entity,
+                field: fact.field,
+                source: fact.source,
+                value: fact.value,
+                stated_at: fact.stated_at,
+            })
+            .collect();
+
+        Ok(Transaction {
+            id: tx_id,
+            fact_ids: vec![],
+            facts,
+        })
+    }
+
+    async fn commit(&self, tx: Transaction) -> PachaResult<TxId> {
+        self.storage.store_facts(&tx.facts).await?;
+        self.storage.store_transaction(&tx).await?;
+        self.indexer.index(&tx.facts).await?;
+        self.consolidator.consolidate(&tx.facts).await?;
+        Ok(tx.id)
+    }
+}
+
+pub enum Scan {
+    Entity(String),
+    EntityField(String, String),
+    Field(String),
+    FieldValue(String, String),
+    EntityValue(String, String),
+    Value(String),
+}
+
+pub enum QueryPlan {
+    RunScan(TxId, Vec<Scan>, Box<QueryPlan>),
+    Solve,
+}
+
+#[async_trait(?Send)]
+pub trait QueryPlanner {
+    async fn plan_query(&self, query: String, tx_id: TxId) -> PachaResult<QueryPlan>;
+}
+
+#[derive(Default)]
+pub struct DefaultQueryPlanner {}
+
+#[async_trait(?Send)]
+impl QueryPlanner for DefaultQueryPlanner {
+    async fn plan_query(&self, query: String, tx_id: TxId) -> PachaResult<QueryPlan> {
+        let query = Parser.parse(&query)?;
+
+        let scans: Vec<Scan> = query
+            .body
+            .iter()
+            .flat_map(|atom| match &atom.relation {
+                Term::Var(_) => {
+                    let entity = atom.args.get(0).unwrap();
+                    let value = atom.args.get(1).unwrap();
+                    match (entity, value) {
+                        (Term::Var(_), Term::Sym(v)) => vec![Scan::Value(v.clone())],
+                        (Term::Sym(e), Term::Var(_)) => vec![Scan::Entity(e.clone())],
+                        (Term::Sym(e), Term::Sym(v)) => {
+                            vec![Scan::EntityValue(e.clone(), v.clone())]
+                        }
+                        (Term::Var(_), Term::Var(_)) => vec![],
+                    }
+                }
+                Term::Sym(f) => {
+                    let entity = atom.args.get(0).unwrap();
+                    let value = atom.args.get(1).unwrap();
+                    match (entity, value) {
+                        (Term::Var(_), Term::Sym(v)) => {
+                            vec![Scan::FieldValue(f.clone(), v.clone())]
+                        }
+                        (Term::Sym(e), Term::Var(_)) => {
+                            vec![Scan::EntityField(e.clone(), f.clone())]
+                        }
+                        (Term::Sym(_), Term::Sym(_)) => vec![],
+                        (Term::Var(_), Term::Var(_)) => vec![Scan::Field(f.clone())],
+                    }
+                }
+            })
+            .collect();
+
+        Ok(QueryPlan::RunScan(tx_id, scans, QueryPlan::Solve.into()))
+    }
+}
+
+#[async_trait(?Send)]
+pub trait QueryExecutor {
+    async fn run_query_plan(&self, plan: QueryPlan) -> PachaResult<Vec<Atom>>;
+}
+
+pub struct IndexKey {
+    pub prefix: String,
+    pub tx_id: TxId,
+}
+
+impl ToString for IndexKey {
+    fn to_string(&self) -> String {
+        format!("{}/{}", self.prefix.clone(), self.tx_id.0)
+    }
+}
+
+impl FromStr for IndexKey {
+    type Err = PachaError;
+
+    fn from_str(key: &str) -> Result<Self, Self::Err> {
+        let fact_tx_id: u64 = key.split('/').last().unwrap().parse().unwrap();
+        Ok(Self {
+            prefix: key.to_string(),
+            tx_id: TxId(fact_tx_id),
+        })
+    }
+}
+
+#[async_trait(?Send)]
+pub trait IndexStore {
+    async fn scan(&self, prefix: &str) -> PachaResult<Box<dyn Iterator<Item = IndexKey>>>;
+    async fn get(&self, key: IndexKey) -> PachaResult<Option<Fact>>;
+}
+
+pub struct DefaultQueryExecutor<IS: IndexStore> {
+    scanner: IndexScanner<IS>,
+    solver: Solver,
+}
+
+#[async_trait(?Send)]
+impl<IS> QueryExecutor for DefaultQueryExecutor<IS>
+where
+    IS: IndexStore,
+{
+    async fn run_query_plan(&self, plan: QueryPlan) -> PachaResult<Vec<Atom>> {
+        self.do_run_query(plan, vec![]).await
+    }
+}
+
+impl<IS> DefaultQueryExecutor<IS>
+where
+    IS: IndexStore,
+{
+    pub fn new(scanner: IndexScanner<IS>) -> Self {
+        Self {
+            scanner,
+            solver: Solver,
+        }
+    }
+
+    #[async_recursion(?Send)]
+    async fn do_run_query(&self, plan: QueryPlan, mut rules: Vec<Rule>) -> PachaResult<Vec<Atom>> {
+        match plan {
+            QueryPlan::RunScan(tx_id, scans, next) => {
+                for scan in scans {
+                    let new_rules = self.scanner.fetch(scan, tx_id).await?;
+                    rules.extend(new_rules);
+                }
+                self.do_run_query(*next, rules).await
+            }
+            QueryPlan::Solve => Ok(self.solver.solve(rules)),
+        }
+    }
+}
+
+pub struct IndexScanner<IS: IndexStore> {
+    index_by_entity: IS,
+    index_by_entity_field: IS,
+    index_by_entity_value: IS,
+    index_by_field: IS,
+    index_by_field_value: IS,
+    index_by_value: IS,
+}
+
+impl<IS: IndexStore> IndexScanner<IS> {
+    pub fn new(
+        index_by_entity: IS,
+        index_by_entity_field: IS,
+        index_by_entity_value: IS,
+        index_by_field: IS,
+        index_by_field_value: IS,
+        index_by_value: IS,
+    ) -> Self {
+        Self {
+            index_by_entity,
+            index_by_entity_field,
+            index_by_entity_value,
+            index_by_field,
+            index_by_field_value,
+            index_by_value,
+        }
+    }
+
+    pub async fn fetch(&self, scan: Scan, max_tx: TxId) -> PachaResult<Vec<Rule>> {
+        let (kv, prefix) = match scan {
+            Scan::Entity(prefix) => (&self.index_by_entity, prefix),
+            Scan::EntityField(e, f) => (&self.index_by_entity_field, format!("{}/{}", e, f)),
+            Scan::Field(f) => (&self.index_by_field, f),
+            Scan::FieldValue(f, v) => (&self.index_by_field_value, format!("{}/{}", f, v)),
+            Scan::EntityValue(e, v) => (&self.index_by_entity_value, format!("{}/{}", e, v)),
+            Scan::Value(v) => (&self.index_by_value, v),
+        };
+
+        let mut rules = vec![];
+        for key in kv.scan(&prefix).await? {
+            if key.tx_id <= max_tx {
+                let fact = kv.get(key).await?.unwrap();
+                let rule = rule!(
+                    atom!(sym!(fact.entity.0), sym!(fact.field.0), sym!(fact.value)),
+                    vec![]
+                );
+                rules.push(rule);
+            }
+        }
+
+        Ok(rules)
     }
 }

--- a/core/src/model.rs
+++ b/core/src/model.rs
@@ -1,0 +1,112 @@
+use crate::*;
+use chrono::{DateTime, Utc};
+use serde_derive::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Uri(pub String);
+
+impl ToString for Uri {
+    fn to_string(&self) -> String {
+        self.0.to_string()
+    }
+}
+
+#[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize)]
+pub enum Value {
+    String(String),
+    Uri(Uri),
+}
+
+impl From<Uri> for Value {
+    fn from(value: Uri) -> Self {
+        Self::Uri(value)
+    }
+}
+
+impl ToString for Value {
+    fn to_string(&self) -> String {
+        match self {
+            Value::String(s) => s.to_string(),
+            Value::Uri(u) => u.to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Fact {
+    pub tx_id: TxId,
+    pub id: Uri,
+    pub entity: Uri,
+    pub field: Uri,
+    pub source: Uri,
+    pub value: Value,
+    #[serde(with = "util::serde::iso8601")]
+    pub stated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UserFact {
+    pub entity: Uri,
+    pub field: Uri,
+    pub source: Uri,
+    pub value: Value,
+    #[serde(with = "util::serde::iso8601")]
+    pub stated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QueryReq {
+    pub query: String,
+    pub tx_id: TxId,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StateFactsReq {
+    pub facts: Vec<UserFact>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StateFactsRes {
+    pub tx_id: TxId,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Entity {
+    pub uri: Uri,
+    pub fields: HashMap<Uri, Value>,
+    pub prior_facts: HashMap<Uri, Fact>,
+    #[serde(with = "util::serde::iso8601")]
+    pub created_at: DateTime<Utc>,
+    #[serde(with = "util::serde::iso8601")]
+    pub last_updated_at: DateTime<Utc>,
+}
+
+impl Entity {
+    pub fn new(uri: Uri) -> Self {
+        Self {
+            uri,
+            created_at: chrono::Utc::now(),
+            last_updated_at: chrono::Utc::now(),
+            fields: Default::default(),
+            prior_facts: Default::default(),
+        }
+    }
+
+    pub fn consolidate(&mut self, fact: Fact) {
+        if let Some(prior_fact) = self.prior_facts.get(&fact.field) {
+            if fact.stated_at >= prior_fact.stated_at {
+                self.insert_fact(fact);
+            }
+        } else {
+            self.insert_fact(fact);
+        }
+    }
+
+    pub fn insert_fact(&mut self, fact: Fact) {
+        self.fields.insert(fact.field.clone(), fact.value.clone());
+        self.prior_facts.insert(fact.field.clone(), fact);
+        self.last_updated_at = chrono::Utc::now();
+    }
+}

--- a/core/src/query_executor.rs
+++ b/core/src/query_executor.rs
@@ -1,0 +1,191 @@
+use crate::*;
+use async_recursion::async_recursion;
+use async_trait::async_trait;
+use pachadb_nanolog::engine::{Atom, Rule, Solver, Term};
+use pachadb_nanolog::{atom, rule, sym};
+use std::collections::HashSet;
+
+#[async_trait(?Send)]
+pub trait QueryExecutor {
+    async fn execute(&self, plan: QueryPlan) -> PachaResult<Vec<Atom>>;
+}
+
+pub struct DefaultQueryExecutor<S: Store, I: Index> {
+    index: I,
+    store: S,
+    solver: Solver,
+}
+
+impl<S, I> DefaultQueryExecutor<S, I>
+where
+    S: Store,
+    I: Index,
+{
+    pub fn new(store: S, index: I) -> Self {
+        Self {
+            index,
+            store,
+            solver: Solver,
+        }
+    }
+
+    #[async_recursion(?Send)]
+    async fn do_run_query(&self, plan: QueryPlan, mut rules: Vec<Rule>) -> PachaResult<Vec<Atom>> {
+        match plan {
+            QueryPlan::RunScan(tx_id, scans, next) => {
+                let rules = self.do_run_scan(tx_id, scans, rules).await?;
+                self.do_run_query(*next, rules).await
+            }
+            QueryPlan::Solve(query) => {
+                rules.push(query);
+                Ok(self.solver.solve(rules))
+            }
+        }
+    }
+
+    async fn do_run_scan(
+        &self,
+        tx_id: TxId,
+        scans: Vec<Scan>,
+        mut rules: Vec<Rule>,
+    ) -> PachaResult<Vec<Rule>> {
+        let mut uris: HashSet<Uri> = HashSet::default();
+        for scan in scans {
+            for key in self.index.scan(scan).await? {
+                if key.tx_id < tx_id {
+                    let uri =
+                        self.index
+                            .get(key)
+                            .await?
+                            .ok_or(PachaError::UnrecoverableStorageError(
+                                "missing fact from index! is the index corrupted?".to_string(),
+                            ))?;
+                    uris.insert(uri);
+                }
+            }
+        }
+
+        for uri in uris {
+            let fact =
+                self.store
+                    .get_fact(uri)
+                    .await?
+                    .ok_or(PachaError::UnrecoverableStorageError(
+                        "missing fact from store! is the index corrupted?".to_string(),
+                    ))?;
+
+            let rule = rule!(
+                atom!(
+                    sym!(fact.entity.0),
+                    sym!(fact.field.0),
+                    sym!(fact.value.to_string())
+                ),
+                vec![]
+            );
+
+            rules.push(rule);
+        }
+
+        Ok(rules)
+    }
+}
+
+#[async_trait(?Send)]
+impl<S, I> QueryExecutor for DefaultQueryExecutor<S, I>
+where
+    S: Store,
+    I: Index,
+{
+    async fn execute(&self, plan: QueryPlan) -> PachaResult<Vec<Atom>> {
+        self.do_run_query(plan, vec![]).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    #[derive(Clone)]
+    struct UnreachableStore;
+    #[async_trait(?Send)]
+    impl Store for UnreachableStore {
+        async fn get_tx_id(&self) -> PachaResult<TxId> {
+            unreachable!()
+        }
+
+        async fn get_next_tx_id(&self) -> PachaResult<TxId> {
+            unreachable!()
+        }
+
+        async fn get_fact(&self, _uri: Uri) -> PachaResult<Option<Fact>> {
+            unreachable!()
+        }
+
+        async fn put_facts(&self, _facts: impl Iterator<Item = &Fact>) -> PachaResult<()> {
+            unreachable!()
+        }
+
+        async fn put_transaction(&self, _tx: &Transaction) -> PachaResult<()> {
+            unreachable!()
+        }
+    }
+
+    #[quickcheck_async::tokio]
+    async fn on_empty_indices_return_nothing(plan: QueryPlan) -> bool {
+        #[derive(Default, Clone)]
+        struct EmptyIndex;
+        #[async_trait(?Send)]
+        impl Index for EmptyIndex {
+            async fn put(&self, _facts: impl Iterator<Item = &Fact>) -> PachaResult<()> {
+                unreachable!()
+            }
+
+            async fn scan(&self, _prefix: Scan) -> PachaResult<Box<dyn Iterator<Item = IndexKey>>> {
+                Ok(Box::new(vec![].into_iter()))
+            }
+
+            async fn get(&self, _key: IndexKey) -> PachaResult<Option<Uri>> {
+                unreachable!()
+            }
+        }
+
+        let exec = DefaultQueryExecutor::new(UnreachableStore, EmptyIndex);
+        let results = exec.execute(plan).await.unwrap();
+        results.is_empty()
+    }
+
+    #[quickcheck_async::tokio]
+    async fn calls_index(plan: QueryPlan) -> bool {
+        #[derive(Default, Clone)]
+        struct SpyableIndex {
+            was_called: Rc<RefCell<bool>>,
+        }
+        #[async_trait(?Send)]
+        impl Index for SpyableIndex {
+            async fn put(&self, _facts: impl Iterator<Item = &Fact>) -> PachaResult<()> {
+                unreachable!()
+            }
+
+            async fn scan(&self, _prefix: Scan) -> PachaResult<Box<dyn Iterator<Item = IndexKey>>> {
+                self.was_called.replace(true);
+                Ok(Box::new(vec![].into_iter()))
+            }
+
+            async fn get(&self, _key: IndexKey) -> PachaResult<Option<Uri>> {
+                unreachable!()
+            }
+        }
+
+        let was_called = Rc::new(RefCell::new(false));
+        let index = SpyableIndex {
+            was_called: was_called.clone(),
+        };
+        let exec = DefaultQueryExecutor::new(UnreachableStore, index);
+
+        let _results = exec.execute(plan).await.unwrap();
+
+        was_called.take()
+    }
+}

--- a/core/src/query_planner.rs
+++ b/core/src/query_planner.rs
@@ -1,0 +1,219 @@
+use crate::*;
+use pachadb_nanolog::engine::{Rule, Term};
+
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+pub enum Scan {
+    Entity(String),
+    EntityField(String, String),
+    Field(String),
+    FieldValue(String, String),
+    EntityValue(String, String),
+    Value(String),
+}
+
+impl Scan {
+    pub fn to_prefix(&self) -> String {
+        match self {
+            Self::Entity(prefix) => prefix.clone(),
+            Self::EntityField(e, f) => format!("{}/{}", e, f),
+            Self::Field(f) => f.clone(),
+            Self::FieldValue(f, v) => format!("{}/{}", f, v),
+            Self::EntityValue(e, v) => format!("{}/{}", e, v),
+            Self::Value(v) => v.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+pub enum QueryPlan {
+    RunScan(TxId, Vec<Scan>, Box<QueryPlan>),
+    Solve(Rule),
+}
+
+pub trait QueryPlanner {
+    fn plan(&self, query: Rule, tx_id: TxId) -> PachaResult<QueryPlan>;
+}
+
+#[derive(Default, Debug)]
+pub struct DefaultQueryPlanner;
+
+impl QueryPlanner for DefaultQueryPlanner {
+    fn plan(&self, query: Rule, tx_id: TxId) -> PachaResult<QueryPlan> {
+        let scans: Vec<Scan> = query
+            .body
+            .iter()
+            .flat_map(|atom| match &atom.relation {
+                Term::Var(_) => {
+                    let entity = atom.args.get(0).unwrap();
+                    let value = atom.args.get(1).unwrap();
+                    match (entity, value) {
+                        (Term::Var(_), Term::Sym(v)) => vec![Scan::Value(v.clone())],
+                        (Term::Sym(e), Term::Var(_)) => vec![Scan::Entity(e.clone())],
+                        (Term::Sym(e), Term::Sym(v)) => {
+                            vec![Scan::EntityValue(e.clone(), v.clone())]
+                        }
+                        (Term::Var(_), Term::Var(_)) => vec![],
+                    }
+                }
+                Term::Sym(f) => {
+                    let entity = atom.args.get(0).unwrap();
+                    let value = atom.args.get(1).unwrap();
+                    match (entity, value) {
+                        (Term::Var(_), Term::Sym(v)) => {
+                            vec![Scan::FieldValue(f.clone(), v.clone())]
+                        }
+                        (Term::Sym(e), Term::Var(_)) => {
+                            vec![Scan::EntityField(e.clone(), f.clone())]
+                        }
+                        (Term::Sym(_), Term::Sym(_)) => vec![],
+                        (Term::Var(_), Term::Var(_)) => vec![Scan::Field(f.clone())],
+                    }
+                }
+            })
+            .collect();
+
+        Ok(QueryPlan::RunScan(
+            tx_id,
+            scans,
+            QueryPlan::Solve(query).into(),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pachadb_nanolog::engine::{Atom, Rule, Term};
+    use pachadb_nanolog::parser::Parser;
+    use pachadb_nanolog::{atom, query, rule, sym, var};
+    use quickcheck::Arbitrary;
+
+    use super::*;
+
+    /// A Range-restricted rule can be used to generate random rules where all the variables used
+    /// in the head of the rule appear in the rule's body.
+    ///
+    /// This is typically how we create our `query0` rule for evaluating queries.
+    ///
+    #[derive(Debug, Clone)]
+    pub struct RangeRestrictedRule(Rule);
+
+    #[cfg(test)]
+    impl quickcheck::Arbitrary for RangeRestrictedRule {
+        fn arbitrary(g: &mut quickcheck::Gen) -> Self {
+            let body: Vec<Atom> = (0..g.size())
+                .map(|idx| {
+                    let relation = Term::Sym(format!("rel-{}", idx));
+
+                    let vars = vec![
+                        Term::Var(format!("var-{}", u32::arbitrary(g))),
+                        Term::Sym(format!("sym-{}", idx)),
+                    ];
+                    let subject = g.choose(&vars).unwrap().clone();
+                    let object = g.choose(&vars).unwrap().clone();
+
+                    let args = vec![subject, object];
+                    Atom { relation, args }
+                })
+                .collect();
+
+            // NOTE(@ostera): we extract all the variables that are used in the body to make sure
+            // this rule is range restricted.
+            let relation = Term::Sym("query0".to_string());
+            let args: Vec<Term> = body
+                .iter()
+                .flat_map(|a| a.args.clone())
+                .filter(|t| t.is_var())
+                .collect();
+            let head = Atom { relation, args };
+
+            RangeRestrictedRule(Rule { head, body })
+        }
+    }
+
+    impl Arbitrary for QueryPlan {
+        fn arbitrary(g: &mut quickcheck::Gen) -> Self {
+            let query: RangeRestrictedRule = Arbitrary::arbitrary(g);
+
+            if !query.0.is_range_restricted() {
+                panic!("Rule was not range restricted! {:#?}", query.0);
+            }
+
+            DefaultQueryPlanner.plan(query.0, TxId::default()).unwrap()
+        }
+    }
+
+    #[test]
+    fn plans_simple_query() {
+        let planner = DefaultQueryPlanner;
+        let tx_id = TxId::default();
+
+        let rule = Parser.parse("(?who likes rush)").unwrap();
+        let plan = planner.plan(rule, tx_id).unwrap();
+
+        let query = rule!(
+            query!("query0", vec![var!("who")]),
+            vec![atom!(var!("who"), sym!("likes"), sym!("rush"))]
+        );
+
+        assert_eq!(
+            plan,
+            QueryPlan::RunScan(
+                tx_id,
+                vec![Scan::FieldValue("likes".to_string(), "rush".to_string())],
+                QueryPlan::Solve(query).into()
+            )
+        );
+    }
+
+    #[test]
+    fn plans_complex_query() {
+        let planner = DefaultQueryPlanner;
+        let tx_id = TxId::default();
+        let rule = Parser
+            .parse(
+                r#"
+            (
+                ?who likes rush
+                ?who likes ?band
+                ?band is-a music-band
+                ?band plays prog-rock
+             )
+            "#,
+            )
+            .unwrap();
+        let plan = planner.plan(rule, tx_id).unwrap();
+
+        let query = rule!(
+            query!(
+                "query0",
+                vec![
+                    var!("who"),
+                    var!("who"),
+                    var!("band"),
+                    var!("band"),
+                    var!("band"),
+                ]
+            ),
+            vec![
+                atom!(var!("who"), sym!("likes"), sym!("rush")),
+                atom!(var!("who"), sym!("likes"), var!("band")),
+                atom!(var!("band"), sym!("is-a"), sym!("music-band")),
+                atom!(var!("band"), sym!("plays"), sym!("prog-rock")),
+            ]
+        );
+
+        assert_eq!(
+            plan,
+            QueryPlan::RunScan(
+                tx_id,
+                vec![
+                    Scan::FieldValue("likes".to_string(), "rush".to_string()),
+                    Scan::Field("likes".to_string()),
+                    Scan::FieldValue("is-a".to_string(), "music-band".to_string()),
+                    Scan::FieldValue("plays".to_string(), "prog-rock".to_string())
+                ],
+                QueryPlan::Solve(query).into()
+            )
+        );
+    }
+}

--- a/core/src/store.rs
+++ b/core/src/store.rs
@@ -1,0 +1,15 @@
+use crate::*;
+use async_trait::async_trait;
+
+#[async_trait(?Send)]
+pub trait Store: Clone {
+    async fn get_tx_id(&self) -> PachaResult<TxId>;
+
+    async fn get_next_tx_id(&self) -> PachaResult<TxId>;
+
+    async fn get_fact(&self, uri: Uri) -> PachaResult<Option<Fact>>;
+
+    async fn put_facts(&self, facts: impl Iterator<Item = &Fact>) -> PachaResult<()>;
+
+    async fn put_transaction(&self, tx: &Transaction) -> PachaResult<()>;
+}

--- a/core/src/tx_manager.rs
+++ b/core/src/tx_manager.rs
@@ -1,0 +1,99 @@
+use crate::*;
+use async_trait::async_trait;
+use serde_derive::{Deserialize, Serialize};
+
+#[derive(
+    Default, Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize,
+)]
+#[serde(transparent)]
+pub struct TxId(pub u64);
+
+impl TxId {
+    pub fn next(&self) -> Self {
+        Self(self.0 + 1)
+    }
+    pub fn max() -> Self {
+        Self(u64::MAX)
+    }
+}
+
+impl ToString for TxId {
+    fn to_string(&self) -> String {
+        self.0.to_string()
+    }
+}
+
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+pub struct Transaction {
+    pub id: TxId,
+    pub fact_ids: Vec<Uri>,
+    pub facts: Vec<Fact>,
+}
+
+#[async_trait(?Send)]
+pub trait TxManager {
+    async fn transaction(&mut self, facts: Vec<UserFact>) -> PachaResult<Transaction>;
+
+    async fn commit(&mut self, tx: Transaction) -> PachaResult<TxId>;
+
+    async fn last_tx_id(&self) -> PachaResult<TxId>;
+}
+
+pub struct DefaultTxManager<S: Store, I: Index, C: Consolidator> {
+    storage: S,
+    index: I,
+    consolidator: C,
+}
+
+impl<S: Store, I: Index, C: Consolidator> DefaultTxManager<S, I, C> {
+    pub fn new(storage: S, index: I, consolidator: C) -> Self {
+        Self {
+            storage,
+            index,
+            consolidator,
+        }
+    }
+}
+
+#[async_trait(?Send)]
+impl<S, I, C> TxManager for DefaultTxManager<S, I, C>
+where
+    S: Store,
+    I: Index,
+    C: Consolidator,
+{
+    async fn transaction(&mut self, facts: Vec<UserFact>) -> PachaResult<Transaction> {
+        let tx_id: TxId = self.storage.get_next_tx_id().await?;
+
+        let facts = facts
+            .into_iter()
+            .map(|fact| Fact {
+                tx_id,
+                id: Uri(format!("pachadb:fact:{}", uuid::Uuid::new_v4())),
+                entity: fact.entity,
+                field: fact.field,
+                source: fact.source,
+                value: fact.value,
+                stated_at: fact.stated_at,
+            })
+            .collect();
+
+        Ok(Transaction {
+            id: tx_id,
+            fact_ids: vec![],
+            facts,
+        })
+    }
+
+    async fn commit(&mut self, tx: Transaction) -> PachaResult<TxId> {
+        self.storage.put_facts(tx.facts.iter()).await?;
+        self.storage.put_transaction(&tx).await?;
+        self.index.put(tx.facts.iter()).await?;
+        self.consolidator.consolidate(tx.facts.iter()).await?;
+        Ok(tx.id)
+    }
+
+    async fn last_tx_id(&self) -> PachaResult<TxId> {
+        self.storage.get_tx_id().await
+    }
+}

--- a/examples/cloudflare-simple/.editorconfig
+++ b/examples/cloudflare-simple/.editorconfig
@@ -1,0 +1,13 @@
+# http://editorconfig.org
+root = true
+
+[*]
+indent_style = tab
+tab_width = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.yml]
+indent_style = space

--- a/examples/cloudflare-simple/.prettierrc
+++ b/examples/cloudflare-simple/.prettierrc
@@ -1,0 +1,6 @@
+{
+	"printWidth": 140,
+	"singleQuote": true,
+	"semi": true,
+	"useTabs": true
+}

--- a/examples/cloudflare-simple/Cargo.toml
+++ b/examples/cloudflare-simple/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "pachadb-cloud-worker-query"
+name = "pachadb-examples-cloudflare-simple"
 version = "0.1.0"
 edition = "2021"
 
@@ -10,16 +10,17 @@ crate-type = ["cdylib", "rlib"]
 default = ["console_error_panic_hook"]
 
 [dependencies]
-pachadb-core = { path = "../core", version = "*" }
-pachadb-backend-cloudflare = { path = "../backend-cloudflare", version = "*" }
+pachadb-core = { path = "../../core", version = "*" }
+pachadb-backend-cloudflare = { path = "../../backend-cloudflare", version = "*" }
 
-chrono.workspace = true
+worker.workspace = true
 console_error_panic_hook = { version = "0.1.1", optional = true }
-futures.workspace = true
-log.workspace = true
-reqwest.workspace = true
 serde = { workspace = true }
 serde_json = { workspace = true }
+futures.workspace = true
 uuid.workspace = true
+reqwest.workspace = true
+chrono.workspace = true
 wasm-logger.workspace = true
-worker.workspace = true
+log.workspace = true
+maud = "0.25.0"

--- a/examples/cloudflare-simple/client.properties
+++ b/examples/cloudflare-simple/client.properties
@@ -1,0 +1,9 @@
+# Required connection configs for Kafka producer, consumer, and admin
+bootstrap.servers=pkc-zm3p0.eu-north-1.aws.confluent.cloud:9092
+security.protocol=SASL_SSL
+sasl.mechanisms=PLAIN
+sasl.username=GDGDY5E7UWSMER4W
+sasl.password=KK0RbasKL7NxCfDJdjhs6PwZvGl5gWsmJ8cxxPVeXjHSL0vBmGmG8ccdizHGbjJZ
+
+# Best practice for higher availability in librdkafka clients prior to 1.7
+session.timeout.ms=45000

--- a/examples/cloudflare-simple/package.json
+++ b/examples/cloudflare-simple/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "pachadb-worker",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "deploy": "wrangler deploy",
+    "start": "wrangler dev"
+  },
+  "devDependencies": {
+    "wrangler": "^3.0.0"
+  }
+}

--- a/examples/cloudflare-simple/src/lib.rs
+++ b/examples/cloudflare-simple/src/lib.rs
@@ -1,0 +1,63 @@
+extern crate console_error_panic_hook;
+use log::*;
+use maud::{html, Markup};
+use pachadb_core::*;
+use std::panic;
+use worker::*;
+
+#[event(fetch, respond_with_errors)]
+async fn main(req: Request, env: Env, _ctx: Context) -> Result<Response> {
+    panic::set_hook(Box::new(console_error_panic_hook::hook));
+    wasm_logger::init(wasm_logger::Config::default());
+
+    let router = Router::new();
+
+    router
+				.get_async("/", |_req, ctx| async move {
+					let html = html! {
+						head {
+							title {
+								"PachaDB Simple Example"
+							}
+						}
+						body {
+							h1 {
+								"PachaDB Simple Example"
+							}
+							(form())
+						}
+					};
+
+					Response::from_html(html.into_string())
+				})
+		.post_async("/todos/new", |req, ctx| async move {
+			info!("{:#?}", req);
+			Response::ok("ok")
+		})
+        .run(req, env)
+        .await
+}
+
+fn form() -> Markup {
+	html! {
+		form action="/todos/new" method="POST" {
+			(input("todo"))
+			(button("add", "submit"))
+		}
+	}
+}
+
+fn button(name: &str, kind: &str) -> Markup {
+	html! {
+		button type=(kind) { (name) }
+	}
+}
+
+fn input(name: &str) -> Markup {
+	html! {
+			label for="todo" {
+				span { (name) }
+				input id="todo" placeholder="Something to do...";
+			}
+	}
+}

--- a/examples/cloudflare-simple/wrangler.toml
+++ b/examples/cloudflare-simple/wrangler.toml
@@ -1,0 +1,34 @@
+name = "pachadb-examples-cloudflare-simple"
+main = "build/worker/shim.mjs"
+compatibility_date = "2023-07-24"
+
+usage_model = "bundled"
+
+[build]
+command = "cargo install worker-build && worker-build --release"
+
+# kv_namespaces = [
+#   { binding = "playground-pachadb-entities-store", id = "f65a15f705814e5eb00202ef19ed27ca" },
+#   { binding = "playground-pachadb-facts-index-by-entity", id = "f2780bd63f1a4c81be67a8f75fe52d22" },
+#   { binding = "playground-pachadb-facts-index-by-entity-field", id = "df3df3088fe64c9b8f2c616f312dbd09" },
+#   { binding = "playground-pachadb-facts-index-by-field", id = "5780f94195774bdfa5519f76c951999d" },
+#   { binding = "playground-pachadb-facts-index-by-field-value", id = "be25916199f54ca698d26fcc1e543306" },
+#   { binding = "playground-pachadb-facts-index-by-value", id = "5f2051b170984d979a7da8580d9cd83f" },
+#   { binding = "playground-pachadb-facts-store", id = "88c04e76bdb04ff78783cc5d850c86ac" },
+#   { binding = "playground-pachadb-tx-store", id = "4efeddcbd90b4d3aa9e76b9efb01867c" },
+# ]
+#
+# [durable_objects]
+# bindings = [{ name = "PLAYGROUND_PACHADB_TX_MANAGER", class_name = "DurObjTxManager" }]
+#
+# [[queues.producers]]
+# queue = "playground-pachadb-facts-indexing"
+# binding = "playground-pachadb-facts-indexing-queue"
+#
+# [[queues.producers]]
+# queue = "playground-pachadb-facts-consolidation"
+# binding = "playground-pachadb-facts-consolidation-queue"
+#
+# [[migrations]]
+# tag = "v1"
+# new_classes = ["DurObjTxManager"]

--- a/nanolog-repl/Cargo.toml
+++ b/nanolog-repl/Cargo.toml
@@ -10,4 +10,4 @@ path = "src/repl.rs"
 
 [dependencies]
 pachadb-nanolog = { path = "../nanolog", version = "*" }
-rustyline = "12.0.0"
+rustyline.workspace = true

--- a/nanolog/Cargo.toml
+++ b/nanolog/Cargo.toml
@@ -4,11 +4,14 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-lalrpop-util = { version = "0.20", features = ["lexer", "unicode"] }
+lalrpop-util.workspace = true
 serde.workspace = true
 serde_derive.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 
 [build-dependencies]
-lalrpop = "0.20"
+lalrpop.workspace = true
+
+[dev-dependencies]
+quickcheck.workspace = true

--- a/nanolog/src/engine.rs
+++ b/nanolog/src/engine.rs
@@ -206,10 +206,6 @@ impl Solver {
     }
 }
 
-struct QueryPlanner {}
-
-impl QueryPlanner {}
-
 impl std::fmt::Debug for Term {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -311,7 +307,35 @@ macro_rules! rule {
 }
 
 #[cfg(test)]
-mod tests {
+impl quickcheck::Arbitrary for Term {
+    fn arbitrary(g: &mut quickcheck::Gen) -> Self {
+        let str = String::arbitrary(g);
+        g.choose(&[Self::Var(str.clone()), Self::Sym(str)])
+            .unwrap()
+            .clone()
+    }
+}
+
+#[cfg(test)]
+impl quickcheck::Arbitrary for Atom {
+    fn arbitrary(g: &mut quickcheck::Gen) -> Self {
+        let relation = Term::arbitrary(g);
+        let args: Vec<Term> = Vec::arbitrary(g);
+        Atom { relation, args }
+    }
+}
+
+#[cfg(test)]
+impl quickcheck::Arbitrary for Rule {
+    fn arbitrary(g: &mut quickcheck::Gen) -> Self {
+        let head = Atom::arbitrary(g);
+        let body: Vec<Atom> = Vec::arbitrary(g);
+        Rule { head, body }
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
     use super::*;
 
     #[test]

--- a/nanolog/src/parser.rs
+++ b/nanolog/src/parser.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use crate::ast::*;
 use crate::atom;
 use crate::engine::{Atom, Rule, Term};
@@ -67,6 +69,14 @@ pub enum ParseError {
 impl ParseError {
     fn unsupported(str: &str) -> Result<Rule, ParseError> {
         Err(Self::Unsupported(str.to_string()))
+    }
+}
+
+impl FromStr for Rule {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Parser.parse(s)
     }
 }
 

--- a/worker-consolidation/Cargo.toml
+++ b/worker-consolidation/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "pachadb-worker-consolidation"
+name = "pachadb-cloud-worker-consolidation"
 version = "0.1.0"
 edition = "2021"
 
@@ -11,6 +11,7 @@ default = ["console_error_panic_hook"]
 
 [dependencies]
 pachadb-core = { path = "../core", version = "*" }
+pachadb-backend-cloudflare = { path = "../backend-cloudflare", version = "*" }
 
 worker.workspace = true
 console_error_panic_hook = { version = "0.1.1", optional = true }

--- a/worker-indexing/Cargo.toml
+++ b/worker-indexing/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "pachadb-worker-indexing"
+name = "pachadb-cloud-worker-indexing"
 version = "0.1.0"
 edition = "2021"
 
@@ -11,6 +11,7 @@ default = ["console_error_panic_hook"]
 
 [dependencies]
 pachadb-core = { path = "../core", version = "*" }
+pachadb-backend-cloudflare = { path = "../backend-cloudflare", version = "*" }
 
 worker.workspace = true
 console_error_panic_hook = { version = "0.1.1", optional = true }

--- a/worker-intake/Cargo.toml
+++ b/worker-intake/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "pachadb-worker-intake"
+name = "pachadb-cloud-worker-intake"
 version = "0.1.0"
 edition = "2021"
 
@@ -11,6 +11,7 @@ default = ["console_error_panic_hook"]
 
 [dependencies]
 pachadb-core = { path = "../core", version = "*" }
+pachadb-backend-cloudflare = { path = "../backend-cloudflare", version = "*" }
 
 worker.workspace = true
 console_error_panic_hook = { version = "0.1.1", optional = true }

--- a/worker-intake/wrangler.toml
+++ b/worker-intake/wrangler.toml
@@ -32,3 +32,8 @@ command = "cargo install worker-build && worker-build --release"
 [[migrations]]
 tag = "v1"
 new_classes = ["TxManager"]
+
+[[migrations]]
+tag = "v2"
+new_classes = ["DurObjTxManager"]
+deleted_classes = ["TxManager"]

--- a/worker-query/src/lib.rs
+++ b/worker-query/src/lib.rs
@@ -1,4 +1,5 @@
 extern crate console_error_panic_hook;
+use async_trait::async_trait;
 use log::*;
 use pachadb_core::*;
 use pachadb_nanolog::engine::*;
@@ -8,12 +9,41 @@ use std::panic;
 use worker::kv::KvStore;
 use worker::*;
 
-#[event(queue)]
-async fn handle_event(_batch: MessageBatch<Uri>, _env: Env, _ctx: Context) -> Result<()> {
-    panic::set_hook(Box::new(console_error_panic_hook::hook));
-    wasm_logger::init(wasm_logger::Config::default());
+pub struct CloudflareIndexStore {
+    kv: KvStore,
+}
 
-    Ok(())
+impl CloudflareIndexStore {
+    pub fn new(env: &Env, kv: &str) -> Result<Self> {
+        let kv = env.kv(kv)?;
+        Ok(Self { kv })
+    }
+}
+
+#[async_trait(?Send)]
+impl IndexStore for CloudflareIndexStore {
+    async fn scan(&self, prefix: &str) -> PachaResult<Box<dyn Iterator<Item = IndexKey>>> {
+        let list = self
+            .kv
+            .list()
+            .prefix(prefix.to_string())
+            .execute()
+            .await
+            .map_err(|err| PachaError::UnrecoverableStorageError(err.to_string()))?;
+
+        Ok(Box::new(
+            list.keys.into_iter().map(|key| key.name.parse().unwrap()),
+        ))
+    }
+
+    //NOTE(@ostera): make sure this retunrs an option
+    async fn get(&self, key: IndexKey) -> PachaResult<Option<Fact>> {
+        self.kv
+            .get(&key.to_string())
+            .json::<Fact>()
+            .await
+            .map_err(|err| PachaError::UnrecoverableStorageError(err.to_string()))
+    }
 }
 
 #[event(fetch)]
@@ -23,87 +53,118 @@ async fn handle_request(req: Request, env: Env, _ctx: Context) -> Result<Respons
 
     let router = Router::new();
 
+    // 0..1..2..X..4 -> monotonic reads / read your writes / serializability
+
+    // 	InMemory
+    // 	FileSystem
+    // 	EdgeWorkerCloudlfare <- monotonic reads + snapshot isolation
+    // 		KV
+
     router
         .post_async("/", |mut req, ctx| async move {
             let query_req: QueryReq = req.json().await?;
 
+            let index_scanner = IndexScanner::new(
+                CloudflareIndexStore::new(&ctx.env, "pachadb-facts-index-by-entity")?,
+                CloudflareIndexStore::new(&ctx.env, "pachadb-facts-index-by-entity-field")?,
+                CloudflareIndexStore::new(&ctx.env, "pachadb-facts-index-by-entity-field")?,
+                CloudflareIndexStore::new(&ctx.env, "pachadb-facts-index-by-field")?,
+                CloudflareIndexStore::new(&ctx.env, "pachadb-facts-index-by-field-value")?,
+                CloudflareIndexStore::new(&ctx.env, "pachadb-facts-index-by-value")?,
+            );
+            let query_executor = DefaultQueryExecutor::new(index_scanner);
+            let query_planner = DefaultQueryPlanner::default();
+
+            let query_plan = query_planner
+                .plan_query(query_req.query, query_req.tx_id)
+                .await
+                .map_err(|err| Error::RustError(err.to_string()))?;
+
+            let result = query_executor
+                .run_query_plan(query_plan)
+                .await
+                .map_err(|err| Error::RustError(err.to_string()))?;
+
             // NOTE(@ostera): helps ensure read-your-writes by forcing replication of facts
-            let tx_bucket = ctx.env.kv("pachadb-tx-store")?;
-            let mut forced_fact_ids = vec![];
-            for tx_id in 0..query_req.tx_id.0 {
-                let tx = tx_bucket
-                    .get(&tx_id.to_string())
-                    .json::<Transaction>()
-                    .await?
-                    .ok_or(worker::Error::RustError(format!(
-                        "missing transaction {}",
-                        tx_id
-                    )))?;
-                forced_fact_ids.extend(tx.fact_ids);
-            }
+            // let tx_bucket = ctx.env.kv("pachadb-tx-store")?;
+            // let mut forced_fact_ids = vec![];
+            // for tx_id in 0..query_req.tx_id.0 {
+            //     let tx = tx_bucket
+            //         .get(&tx_id.to_string())
+            //         .json::<Transaction>()
+            //         .await?
+            //         .ok_or(worker::Error::RustError(format!(
+            //             "missing transaction {}",
+            //             tx_id
+            //         )))?;
+            //     forced_fact_ids.extend(tx.fact_ids);
+            // }
 
-            let query = Parser.parse(&query_req.query).unwrap();
-            info!("Executing {:?}", query);
+            // let query = Parser.parse(&query_req.query).unwrap();
+            // info!("Executing {:?}", query);
 
-            let scans: Vec<Scan> = query
-                .body
-                .iter()
-                .flat_map(|atom| match &atom.relation {
-                    Term::Var(_) => {
-                        let entity = atom.args.get(0).unwrap();
-                        let value = atom.args.get(1).unwrap();
-                        match (entity, value) {
-                            (Term::Var(_), Term::Sym(v)) => vec![Scan::Value(v.clone())],
-                            (Term::Sym(e), Term::Var(_)) => vec![Scan::Entity(e.clone())],
-                            (Term::Sym(e), Term::Sym(v)) => {
-                                vec![Scan::EntityValue(e.clone(), v.clone())]
-                            }
-                            (Term::Var(_), Term::Var(_)) => vec![],
-                        }
-                    }
-                    Term::Sym(f) => {
-                        let entity = atom.args.get(0).unwrap();
-                        let value = atom.args.get(1).unwrap();
-                        match (entity, value) {
-                            (Term::Var(_), Term::Sym(v)) => {
-                                vec![Scan::FieldValue(f.clone(), v.clone())]
-                            }
-                            (Term::Sym(e), Term::Var(_)) => {
-                                vec![Scan::EntityField(e.clone(), f.clone())]
-                            }
-                            (Term::Sym(_), Term::Sym(_)) => vec![],
-                            (Term::Var(_), Term::Var(_)) => vec![Scan::Field(f.clone())],
-                        }
-                    }
-                })
-                .collect();
-            info!("Performing {} scans...", scans.len());
+            // ?who master-of anakin -> Scan::FieldValue("master-of", "anakin")
+            // ?who master-of anakin -> Scan::FieldValue("master-of", "anakin")
 
-            let mut facts = {
-                let scanner = Scanner {
-                    index_by_entity: ctx.env.kv("pachadb-facts-index-by-entity")?,
-                    index_by_entity_field: ctx.env.kv("pachadb-facts-index-by-entity-field")?,
-                    // TODO(@ostera): we don't have this one!
-                    index_by_entity_value: ctx.env.kv("pachadb-facts-index-by-entity-field")?,
-                    index_by_field: ctx.env.kv("pachadb-facts-index-by-field")?,
-                    index_by_field_value: ctx.env.kv("pachadb-facts-index-by-field-value")?,
-                    index_by_value: ctx.env.kv("pachadb-facts-index-by-value")?,
-                };
+            // let scans: Vec<Scan> = query
+            //     .body
+            //     .iter()
+            //     .flat_map(|atom| match &atom.relation {
+            //         Term::Var(_) => {
+            //             let entity = atom.args.get(0).unwrap();
+            //             let value = atom.args.get(1).unwrap();
+            //             match (entity, value) {
+            //                 (Term::Var(_), Term::Sym(v)) => vec![Scan::Value(v.clone())],
+            //                 (Term::Sym(e), Term::Var(_)) => vec![Scan::Entity(e.clone())],
+            //                 (Term::Sym(e), Term::Sym(v)) => {
+            //                     vec![Scan::EntityValue(e.clone(), v.clone())]
+            //                 }
+            //                 (Term::Var(_), Term::Var(_)) => vec![],
+            //             }
+            //         }
+            //         Term::Sym(f) => {
+            //             let entity = atom.args.get(0).unwrap();
+            //             let value = atom.args.get(1).unwrap();
+            //             match (entity, value) {
+            //                 (Term::Var(_), Term::Sym(v)) => {
+            //                     vec![Scan::FieldValue(f.clone(), v.clone())]
+            //                 }
+            //                 (Term::Sym(e), Term::Var(_)) => {
+            //                     vec![Scan::EntityField(e.clone(), f.clone())]
+            //                 }
+            //                 (Term::Sym(_), Term::Sym(_)) => vec![],
+            //                 (Term::Var(_), Term::Var(_)) => vec![Scan::Field(f.clone())],
+            //             }
+            //         }
+            //     })
+            //     .collect();
+            // info!("Performing {} scans...", scans.len());
 
-                let mut facts = vec![];
-                for scan in scans {
-                    facts.extend(
-                        scanner
-                            .fetch(scan, &forced_fact_ids, query_req.tx_id)
-                            .await?,
-                    );
-                }
-                facts
-            };
-            facts.push(query);
+            // let mut facts = {
+            //     let scanner = Scanner {
+            //         index_by_entity: ctx.env.kv("pachadb-facts-index-by-entity")?,
+            //         index_by_entity_field: ctx.env.kv("pachadb-facts-index-by-entity-field")?,
+            //         // TODO(@ostera): we don't have this one!
+            //         index_by_entity_value: ctx.env.kv("pachadb-facts-index-by-entity-field")?,
+            //         index_by_field: ctx.env.kv("pachadb-facts-index-by-field")?,
+            //         index_by_field_value: ctx.env.kv("pachadb-facts-index-by-field-value")?,
+            //         index_by_value: ctx.env.kv("pachadb-facts-index-by-value")?,
+            //     };
 
-            let result = Solver.solve(facts);
-            info!("Result {:?}", result);
+            //     let mut facts = vec![];
+            //     for scan in scans {
+            //         facts.extend(
+            //             scanner
+            //                 .fetch(scan, &forced_fact_ids, query_req.tx_id)
+            //                 .await?,
+            //         );
+            //     }
+            //     facts
+            // };
+            // facts.push(query);
+
+            // let result = Solver.solve(facts);
+            // info!("Result {:?}", result);
 
             Response::from_json(&result)
         })


### PR DESCRIPTION
To be able to run PachaDB in several places (in-browser, deno, cloudflare workers, rust projects, standalone, etc) it makes sense to detach how it works from the underlying IO layer.

To do this I've introduced a few interfaces that help plug in different parts of the IO layer as needed, and refactor the intake and query workers to start using them.

I haven't tested this yet, but it at least compiles.

This also splits the Query stage into a Planner and an Executor, that we can use for optimizing whatever plan we come up with in the future, and for figuring out how to execute a query more efficiently (eg. parallely) depending on the IO we're on.

As an example, on Cloudflare Workers we wouldn't be able to massively parallelize by having a worker reach out to N workers, because there's up to 6 concurrent fetch requests allowed.

However, locally, that would be fine.